### PR TITLE
motion: disable jitter correction on server

### DIFF
--- a/server/src/ctrl.cpp
+++ b/server/src/ctrl.cpp
@@ -40,6 +40,7 @@ flatbuffers::FlatBufferBuilder get_ctrl_as_netprotocol() {
 
   sceMotionSetGyroBiasCorrection(1);
   sceMotionSetTiltCorrection(1);
+  sceMotionSetDeadband(0);
 
   flatbuffers::FlatBufferBuilder builder(512);
 


### PR DESCRIPTION
Disabled deadbanding to make gyro more accurate. Steam, JSM etc already apply jitter correction so there's no need to do it twice.

(cherry picked from commit cddf07a2e624e61c4e798c157c3028853017486e)